### PR TITLE
Implement the functionality of changing color and thickness of ToolItem's

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,9 @@ add_executable(boardroom
 	"Items/Shapes/TriangleItem.hpp"
 	"Items/Shapes/TriangleItem.cpp"
 
+	"Items/Core/DrawingItemBase.hpp"
+	"Items/Core/DrawingItemBase.cpp"
+
 	"Items/FreeDrawingItem.hpp"
 	"Items/FreeDrawingItem.cpp"
 

--- a/src/Items/Core/DrawingItemBase.cpp
+++ b/src/Items/Core/DrawingItemBase.cpp
@@ -1,0 +1,23 @@
+#include "DrawingItemBase.hpp"
+
+#include <QPainter>
+
+DrawingItemBase::DrawingItemBase(QColor color, qreal thickness)
+	: m_color(color), m_thickness(thickness)
+{
+}
+
+void DrawingItemBase::copyTo(ToolItemBase* target) const
+{
+	base_t::copyTo(target);
+	if (auto casted = dynamic_cast<DrawingItemBase*>(target))
+	{
+		casted->m_color = m_color;
+		casted->m_thickness = m_thickness;
+	}
+}
+
+void DrawingItemBase::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
+{
+	painter->setPen(QPen{ m_color, m_thickness });
+}

--- a/src/Items/Core/DrawingItemBase.hpp
+++ b/src/Items/Core/DrawingItemBase.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Items/Core/ToolItemBase.hpp"
+
+class DrawingItemBase : public ToolItemBase
+{
+	using base_t = ToolItemBase;
+	using this_t = DrawingItemBase;
+
+private:
+	QColor m_color;
+	qreal m_thickness;
+
+public:
+	DrawingItemBase(QColor color = Qt::darkBlue, qreal thickness = 2.0);
+
+	void copyTo(ToolItemBase* target) const override;
+
+protected:
+	void onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) override;
+};

--- a/src/Items/Core/ToolItemBase.cpp
+++ b/src/Items/Core/ToolItemBase.cpp
@@ -1,5 +1,7 @@
 #include "Items/Core/ToolItemBase.hpp"
 
+#include <QPainter>
+
 QGraphicsItem* ToolItemBase::getSceneItem()
 { return this; }
 
@@ -38,8 +40,26 @@ QRectF ToolItemBase::boundingRect() const
 
 void ToolItemBase::paint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
 {
+	painter->save();
 	onPaint(painter, option, widget);
+	painter->restore();
+
 	m_limitRectBeforeRepaint = getLimitRect();
+}
+
+std::unique_ptr<ToolItemBase> ToolItemBase::clone() const
+{
+	auto thisCopy = getThisCopy();
+	copyTo(thisCopy.get());
+
+	return thisCopy;
+}
+
+void ToolItemBase::copyTo(ToolItemBase* target) const
+{
+	target->m_pathStartPt = m_pathStartPt;
+	target->m_currentPathPt = m_currentPathPt;
+	target->m_limitRectBeforeRepaint = m_limitRectBeforeRepaint;
 }
 
 void ToolItemBase::onPathStart()

--- a/src/Items/Core/ToolItemBase.hpp
+++ b/src/Items/Core/ToolItemBase.hpp
@@ -25,7 +25,8 @@ private:
 public:
 	~ToolItemBase() override = default;
 
-	virtual std::unique_ptr<ToolItemBase> clone() const = 0;
+	virtual std::unique_ptr<ToolItemBase> clone() const;
+	virtual void copyTo(ToolItemBase* target) const;
 
 	virtual id_t getId() const = 0;
 	virtual QString getName() const = 0;
@@ -40,6 +41,12 @@ public:
 	void paint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) final;
 
 protected:
+	virtual std::unique_ptr<ToolItemBase> getThisCopy() const = 0;
+
+	template <typename TDerived> requires std::derived_from<TDerived, this_t>
+	static std::unique_ptr<ToolItemBase> getThisCopyImpl()
+	{ return std::make_unique<SelectedConstructionImpl<TDerived>>(); }
+
 	template <typename TDerived> requires std::derived_from<TDerived, this_t>
 	static id_t getIdFromHolder()
 	{

--- a/src/Items/FreeDrawingItem.cpp
+++ b/src/Items/FreeDrawingItem.cpp
@@ -3,14 +3,21 @@
 #include <QGraphicsScene>
 #include <QPainter>
 
-std::unique_ptr<ToolItemBase> FreeDrawingItem::clone() const
-{ return std::make_unique<SelectedConstructionImpl<this_t>>(); }
+void FreeDrawingItem::copyTo(ToolItemBase* target) const
+{
+	base_t::copyTo(target);
+	if (auto casted = dynamic_cast<this_t*>(target))
+		casted->m_path = m_path;
+}
 
 ToolItemBase::id_t FreeDrawingItem::getId() const
 { return ToolItemBase::getIdFromHolder<this_t>(); }
 
 QString FreeDrawingItem::getName() const
 { return "Free drawing"; }
+
+std::unique_ptr<ToolItemBase> FreeDrawingItem::getThisCopy() const
+{ return getThisCopyImpl<this_t>(); }
 
 void FreeDrawingItem::onPathStart()
 { m_path.moveTo(getStartPathPt()); }
@@ -22,4 +29,7 @@ QRectF FreeDrawingItem::getLimitRect() const
 { return m_path.boundingRect(); }
 
 void FreeDrawingItem::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
-{ painter->drawPath(m_path); }
+{
+	base_t::onPaint(painter, option, widget);
+	painter->drawPath(m_path);
+}

--- a/src/Items/FreeDrawingItem.hpp
+++ b/src/Items/FreeDrawingItem.hpp
@@ -1,22 +1,25 @@
 #pragma once
 
+#include "Items/Core/DrawingItemBase.hpp"
 #include "Items/Core/ToolItemBase.hpp"
 
-class FreeDrawingItem : public ToolItemBase
+class FreeDrawingItem : public DrawingItemBase
 {
-	using base_t = ToolItemBase;
+	using base_t = DrawingItemBase;
 	using this_t = FreeDrawingItem;
 
 private:
 	QPainterPath m_path;
 
 public:
-	std::unique_ptr<ToolItemBase> clone() const override;
+	void copyTo(ToolItemBase* target) const override;
 
 	id_t getId() const override;
 	QString getName() const override;
 
 protected:
+	std::unique_ptr<ToolItemBase> getThisCopy() const override;
+
 	void onPathStart() override;
 	void onPathUpdate() override;
 

--- a/src/Items/Shapes/EllipseItem.cpp
+++ b/src/Items/Shapes/EllipseItem.cpp
@@ -2,14 +2,14 @@
 
 #include <QPainter>
 
-std::unique_ptr<ToolItemBase> EllipseItem::clone() const
-{ return std::make_unique<SelectedConstructionImpl<this_t>>(); }
-
 ToolItemBase::id_t EllipseItem::getId() const
 { return ToolItemBase::getIdFromHolder<this_t>(); }
 
 QString EllipseItem::getName() const
 { return "Ellipse"; }
+
+std::unique_ptr<ToolItemBase> EllipseItem::getThisCopy() const
+{ return getThisCopyImpl<this_t>(); }
 
 QRectF EllipseItem::getLimitRect() const
 {
@@ -24,7 +24,7 @@ QRectF EllipseItem::getLimitRect() const
 
 void EllipseItem::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
 {
-	painter->setPen(QPen(Qt::black, 1));
+	base_t::onPaint(painter, option, widget);
 
 	QRectF const ellipseRect = [&]
 	{

--- a/src/Items/Shapes/EllipseItem.hpp
+++ b/src/Items/Shapes/EllipseItem.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
+#include "Items/Core/DrawingItemBase.hpp"
 #include "Items/Core/ToolItemBase.hpp"
 
-class EllipseItem : public ToolItemBase
+class EllipseItem : public DrawingItemBase
 {
+	using base_t = DrawingItemBase;
 	using this_t = EllipseItem;
 
 public:
-	std::unique_ptr<ToolItemBase> clone() const override;
-
 	id_t getId() const override;
 	QString getName() const override;
 
 protected:
+	std::unique_ptr<ToolItemBase> getThisCopy() const override;
+
 	QRectF getLimitRect() const override;
 	void onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) override;
 };

--- a/src/Items/Shapes/LineItem.cpp
+++ b/src/Items/Shapes/LineItem.cpp
@@ -2,14 +2,14 @@
 
 #include <QPainter>
 
-std::unique_ptr<ToolItemBase> LineItem::clone() const
-{ return std::make_unique<SelectedConstructionImpl<this_t>>(); }
-
 ToolItemBase::id_t LineItem::getId() const
 { return ToolItemBase::getIdFromHolder<this_t>(); }
 
 QString LineItem::getName() const
 { return "Line"; }
+
+std::unique_ptr<ToolItemBase> LineItem::getThisCopy() const
+{ return getThisCopyImpl<this_t>(); }
 
 QRectF LineItem::getLimitRect() const
 {
@@ -24,5 +24,6 @@ QRectF LineItem::getLimitRect() const
 
 void LineItem::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
 {
+	base_t::onPaint(painter, option, widget);
 	painter->drawLine(getStartPathPt(), getCurrentPathPt());
 }

--- a/src/Items/Shapes/LineItem.hpp
+++ b/src/Items/Shapes/LineItem.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
+#include "Items/Core/DrawingItemBase.hpp"
 #include "Items/Core/ToolItemBase.hpp"
 
-class LineItem : public ToolItemBase
+class LineItem : public DrawingItemBase
 {
+	using base_t = DrawingItemBase;
 	using this_t = LineItem;
 
 public:
-	std::unique_ptr<ToolItemBase> clone() const override;
-
 	id_t getId() const override;
 	QString getName() const override;
 
 protected:
+	std::unique_ptr<ToolItemBase> getThisCopy() const override;
+
 	QRectF getLimitRect() const override;
 	void onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) override;
 };

--- a/src/Items/Shapes/RectangleItem.cpp
+++ b/src/Items/Shapes/RectangleItem.cpp
@@ -2,14 +2,14 @@
 
 #include <QPainter>
 
-std::unique_ptr<ToolItemBase> RectangleItem::clone() const
-{ return std::make_unique<SelectedConstructionImpl<this_t>>(); }
-
 ToolItemBase::id_t RectangleItem::getId() const
 { return ToolItemBase::getIdFromHolder<this_t>(); }
 
 QString RectangleItem::getName() const
 { return "Rectangle"; }
+
+std::unique_ptr<ToolItemBase> RectangleItem::getThisCopy() const
+{ return getThisCopyImpl<this_t>(); }
 
 QRectF RectangleItem::getLimitRect() const
 {
@@ -23,4 +23,7 @@ QRectF RectangleItem::getLimitRect() const
 }
 
 void RectangleItem::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
-{ painter->drawRect(getLimitRect()); }
+{
+	base_t::onPaint(painter, option, widget);
+	painter->drawRect(getLimitRect());
+}

--- a/src/Items/Shapes/RectangleItem.hpp
+++ b/src/Items/Shapes/RectangleItem.hpp
@@ -1,17 +1,20 @@
-#pragma once 
+#pragma once
+
+#include "Items/Core/DrawingItemBase.hpp"
 #include "Items/Core/ToolItemBase.hpp"
 
-class RectangleItem : public ToolItemBase
+class RectangleItem : public DrawingItemBase
 {
+	using base_t = DrawingItemBase;
 	using this_t = RectangleItem;
 
 public:
-	std::unique_ptr<ToolItemBase> clone() const override;
-
 	id_t getId() const override;
 	QString getName() const override;
 
 protected:
+	std::unique_ptr<ToolItemBase> getThisCopy() const override;
+
 	QRectF getLimitRect() const override;
 	void onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) override;
 };

--- a/src/Items/Shapes/TriangleItem.cpp
+++ b/src/Items/Shapes/TriangleItem.cpp
@@ -3,14 +3,14 @@
 #include <QVector2D>
 #include <QPainter>
 
-std::unique_ptr<ToolItemBase> TriangleItem::clone() const
-{ return std::make_unique<SelectedConstructionImpl<this_t>>(); }
-
 ToolItemBase::id_t TriangleItem::getId() const
 { return ToolItemBase::getIdFromHolder<this_t>(); }
 
 QString TriangleItem::getName() const
 { return "Triangle"; }
+
+std::unique_ptr<ToolItemBase> TriangleItem::getThisCopy() const
+{ return getThisCopyImpl<this_t>(); }
 
 QRectF TriangleItem::getLimitRect() const
 {
@@ -25,6 +25,8 @@ QRectF TriangleItem::getLimitRect() const
 
 void TriangleItem::onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget)
 {
+	base_t::onPaint(painter, option, widget);
+
 	QRectF const& rect = getLimitRect();
 
 	QPainterPath path;

--- a/src/Items/Shapes/TriangleItem.hpp
+++ b/src/Items/Shapes/TriangleItem.hpp
@@ -1,17 +1,20 @@
-#pragma once 
+#pragma once
+
+#include "Items/Core/DrawingItemBase.hpp"
 #include "Items/Core/ToolItemBase.hpp"
 
-class TriangleItem : public ToolItemBase
+class TriangleItem : public DrawingItemBase
 {
+	using base_t = DrawingItemBase;
 	using this_t = TriangleItem;
 
 public:
-	std::unique_ptr<ToolItemBase> clone() const override;
-
 	id_t getId() const override;
 	QString getName() const override;
 
 protected:
+	std::unique_ptr<ToolItemBase> getThisCopy() const override;
+
 	QRectF getLimitRect() const override;
 	void onPaint(QPainter* painter, QStyleOptionGraphicsItem const* option, QWidget* widget) override;
 };


### PR DESCRIPTION
Create a DrawingItemBase that .

Also, all existing items have been transferred to this base class. During the creation process, ToolItemBase was reworked: now it implements clone() itself, children only need to implement getThisCopy() (for example, through the getThisCopyImpl<T>() method from ToolItemBase) and optionally copyTo() (if the child has its own data and the method is not implemented, then only the parent's data is copied)